### PR TITLE
Nested documentation blocks

### DIFF
--- a/xs3p.xsl
+++ b/xs3p.xsl
@@ -2480,11 +2480,6 @@ pre {
      -->
    <xsl:template match="*" mode="properties"/>
 
-   <!--
-     Emtpy template to avoid unwanted output in 'hiddendoc' mode
-     -->
-   <xsl:template match="text()" mode="hiddendoc"/>
-
    <xsl:template match="xsd:element | xsd:attribute | xsd:simpleType" mode="hiddendoc">
       <xsl:if test="./xsd:annotation/xsd:documentation">
          <xsl:variable name="documentation">
@@ -2530,16 +2525,7 @@ pre {
            </div>
          </div>
       </xsl:if>
-   </xsl:template>
-
-   <!--
-     Print hidden documentation blocks for each documented element.
-     Generates pop-up divs for 'annotation' elements, if required.
-        Param(s):
-            component (Node) required
-                Schema component
-     -->
-   <xsl:template match="*" mode="hiddendoc">
+     
       <xsl:apply-templates select="child::node()" mode="hiddendoc"/>
    </xsl:template>
 


### PR DESCRIPTION
The problem:
```
<?xml version="1.0" encoding="UTF-8"?>
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
            targetNamespace="http://www.setasign.com/Konquadrat/Dashboard"
            xmlns="http://www.setasign.com/Konquadrat/Dashboard"
            elementFormDefault="qualified">

    <xsd:element name="dashboard" type="dashboard"/>

    <xsd:complexType name="dashboard">
        <xsd:sequence>
            <xsd:choice minOccurs="0" maxOccurs="unbounded">
                <xsd:element name="diagramWidget" type="rectWidget"/>
            </xsd:choice>
        </xsd:sequence>
    </xsd:complexType>

    <xsd:complexType name="diagramWidget">
        <xsd:annotation>
            <!-- Works fine! -->
            <xsd:documentation>...</xsd:documentation>
        </xsd:annotation>
        <xsd:all>
            <xsd:element name="x" type="xsd:integer" minOccurs="0">
                <xsd:annotation>
                    <!-- Works fine! -->
                    <xsd:documentation>...</xsd:documentation>
                </xsd:annotation>
            </xsd:element>
            <xsd:element name="colors" minOccurs="0">
                <xsd:annotation>
                    <!-- Works fine! -->
                    <xsd:documentation>...</xsd:documentation>
                </xsd:annotation>
                <xsd:complexType>
                    <xsd:sequence>
                        <xsd:element name="color" type="xsd:normalizedString" maxOccurs="unbounded">
                            <xsd:annotation>
                                <!-- DOESN'T WORK! -->
                                <xsd:documentation>...</xsd:documentation>
                            </xsd:annotation>
                        </xsd:element>
                    </xsd:sequence>
                </xsd:complexType>
            </xsd:element>
        </xsd:all>
    </xsd:complexType>
</xsd:schema>
```

The documentation block in diagramWidget//colors//color will not be found by the template hiddendoc. And so the modal window for this will not be generated. The (i) button will be shown for this node but nothing happens if you click on it.

This behavior can be observed for all nested documentation blocks.